### PR TITLE
Fix: Update predict.py for new Cog runtime compatibility

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -4,7 +4,7 @@ import tarfile
 import zipfile
 import mimetypes
 from PIL import Image
-from typing import List
+from typing import List, Optional
 from cog import BasePredictor, Input, Path
 from comfyui import ComfyUI
 from weights_downloader import WeightsDownloader
@@ -115,9 +115,8 @@ class Predictor(BasePredictor):
             description="Your ComfyUI workflow as JSON string or URL. You must use the API version of your workflow. Get it from ComfyUI using 'Save (API format)'. Instructions here: https://github.com/replicate/cog-comfyui",
             default="",
         ),
-        input_file: Path = Input(
-            description="Input image, video, tar or zip file. Read guidance on workflows and input files here: https://github.com/replicate/cog-comfyui. Alternatively, you can replace inputs with URLs in your JSON workflow and the model will download them.",
-            default=None,
+        input_file: Optional[Path] = Input(
+            description="Input image, video, tar or zip file. Read guidance on workflows and input files here: https://github.com/replicate/cog-comfyui. Alternatively, you can replace inputs with URLs in your JSON workflow and the model will download them."
         ),
         return_temp_files: bool = Input(
             description="Return any temporary files, such as preprocessed controlnet images. Useful for debugging.",
@@ -165,6 +164,7 @@ class Predictor(BasePredictor):
         if return_temp_files:
             output_directories.append(COMFYUI_TEMP_OUTPUT_DIR)
 
-        return optimise_images.optimise_image_files(
+        optimised_files = optimise_images.optimise_image_files(
             output_format, output_quality, self.comfyUI.get_files(output_directories)
         )
+        return [Path(p) for p in optimised_files]


### PR DESCRIPTION
This commit resolves a critical `TypeError` crash that occurs in recent Docker images when the server attempts to return a prediction result.

The root cause of the issue is an incompatibility between the legacy `predict()` function signature and the new Cog runtime, which uses an updated version of Pydantic. The old method of defining optional `Path` inputs with `default=None` triggers a deprecated validation path that results in a crash.

This fix updates the `predict.py` script in two key ways to align with the modern Cog API:

1.  **Optional Input Handling**: The `input_file` parameter is now correctly defined as `Optional[Path]` without a `default` argument, which is the proper way to handle optional file inputs in the new runtime.
2.  **Explicit Output Casting**: The return statement now explicitly casts the output files to a list of `Path` objects (`[Path(p) for p in optimised_files]`), ensuring the data structure matches what the new Cog runner expects for serialization.

These changes are in accordance with the new Cog runtime guidelines published on 2025-07-21 and ensure that the model is fully compatible with the latest Cog environment.

Ref: https://replicate.com/changelog/2025-07-21-cog-runtime