### PR TITLE
Fix(requirements.txt): Pin transformers to mitigate breaking changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ torchvision
 torchaudio
 torchsde
 einops
-transformers>=4.49.0
+transformers>=4.49.0,<=4.53.3
 tokenizers>=0.13.3
 sentencepiece
 safetensors>=0.3.0
@@ -65,3 +65,5 @@ open-clip-torch>=2.24.0
 pytorch-lightning>=2.2.1
 huggingface_hub[hf-transfer]
 iopath
+jax>=0.4.28
+gguf


### PR DESCRIPTION
Pinning the `transformers` library to version `4.53.3` to avoid a breaking change introduced in version `4.54.0` that affects the `ComfyUI-HunyuanVideoWrapper` custom node. This change addresses the issues reported, such as the one in https://github.com/kijai/ComfyUI-HunyuanVideoWrapper/issues/497.

The `transformers` requirement has been updated from `transformers>=4.49.0` to `transformers>=4.49.0,<=4.53.3` to ensure compatibility while still allowing minor updates within a known stable range.

Added missing new dependencies:
- `jax>=0.4.28`
- `gguf`